### PR TITLE
add metric -> car visual-language mapping + backfill migration

### DIFF
--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -14,6 +14,7 @@ defmodule BldgServer.Buildings do
     "stage" => %{"3d_object" => "stage", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "enabler" => %{"3d_object" => "blueLot", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "milestone" => %{"3d_object" => "raceGate", "flr_height" => "0.9", "flr0_height" => "0.022"},
+    "metric" => %{"3d_object" => "car", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "task" => %{"3d_object" => "greenLot", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "team" => %{"3d_object" => "buildingWithStorefront", "flr_height" => "0.9", "flr0_height" => "0.05"},
     "storage" => %{"3d_object" => "storageBuilding", "flr_height" => "0.7", "flr0_height" => "0.03"},

--- a/bldg_server/priv/repo/migrations/20260428120000_add_metric_visual_mapping.exs
+++ b/bldg_server/priv/repo/migrations/20260428120000_add_metric_visual_mapping.exs
@@ -1,0 +1,22 @@
+defmodule BldgServer.Repo.Migrations.AddMetricVisualMapping do
+  use Ecto.Migration
+
+  def up do
+    # Add the metric -> car mapping to every existing bldg's visual_language so
+    # bldgs created before metrics-battery shipped also know how to render the
+    # new entity_type. Mirrors the entry added to @default_visual_language in
+    # BldgServer.Buildings.
+    execute """
+    UPDATE bldgs SET visual_language = visual_language ||
+      '{"metric": {"3d_object": "car", "flr_height": "0.9", "flr0_height": "0.022"}}'::jsonb
+    WHERE visual_language IS NOT NULL
+    """
+  end
+
+  def down do
+    execute """
+    UPDATE bldgs SET visual_language = visual_language - 'metric'
+    WHERE visual_language IS NOT NULL
+    """
+  end
+end


### PR DESCRIPTION
- Default visual_language now maps the 'metric' entity_type to the 'car' 3D object so newly-created composite bldgs carry the mapping.
- Migration backfills the metric->car entry into every existing bldg's visual_language JSONB so bldgs created before metrics-battery shipped (including the home and goal containers in pre-existing user offices) also resolve the new entity_type.