### PR TITLE
map metric entity_type to new metricDisplay 3D object

### DIFF
--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -14,7 +14,7 @@ defmodule BldgServer.Buildings do
     "stage" => %{"3d_object" => "stage", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "enabler" => %{"3d_object" => "blueLot", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "milestone" => %{"3d_object" => "raceGate", "flr_height" => "0.9", "flr0_height" => "0.022"},
-    "metric" => %{"3d_object" => "car", "flr_height" => "0.9", "flr0_height" => "0.022"},
+    "metric" => %{"3d_object" => "metricDisplay", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "task" => %{"3d_object" => "greenLot", "flr_height" => "0.9", "flr0_height" => "0.022"},
     "team" => %{"3d_object" => "buildingWithStorefront", "flr_height" => "0.9", "flr0_height" => "0.05"},
     "storage" => %{"3d_object" => "storageBuilding", "flr_height" => "0.7", "flr0_height" => "0.03"},

--- a/bldg_server/priv/repo/migrations/20260519090000_update_metric_visual_mapping.exs
+++ b/bldg_server/priv/repo/migrations/20260519090000_update_metric_visual_mapping.exs
@@ -1,0 +1,27 @@
+defmodule BldgServer.Repo.Migrations.UpdateMetricVisualMapping do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE bldgs
+    SET visual_language = jsonb_set(
+      visual_language,
+      '{metric}',
+      '{"3d_object": "metricDisplay", "flr_height": "0.9", "flr0_height": "0.022"}'::jsonb
+    )
+    WHERE visual_language IS NOT NULL AND visual_language ? 'metric'
+    """
+  end
+
+  def down do
+    execute """
+    UPDATE bldgs
+    SET visual_language = jsonb_set(
+      visual_language,
+      '{metric}',
+      '{"3d_object": "car", "flr_height": "0.9", "flr0_height": "0.022"}'::jsonb
+    )
+    WHERE visual_language IS NOT NULL AND visual_language ? 'metric'
+    """
+  end
+end

--- a/bldg_server/rel/overlays/bin/migrate
+++ b/bldg_server/rel/overlays/bin/migrate
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+exec ./bldg_server eval BldgServer.Release.migrate

--- a/bldg_server/rel/overlays/bin/migrate.bat
+++ b/bldg_server/rel/overlays/bin/migrate.bat
@@ -1,0 +1,3 @@
+@echo off
+cd %~dp0
+call bldg_server eval BldgServer.Release.migrate

--- a/bldg_server/rel/overlays/bin/server
+++ b/bldg_server/rel/overlays/bin/server
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+PHX_SERVER=true exec ./bldg_server start

--- a/bldg_server/rel/overlays/bin/server.bat
+++ b/bldg_server/rel/overlays/bin/server.bat
@@ -1,0 +1,4 @@
+@echo off
+set PHX_SERVER=true
+cd %~dp0
+call bldg_server start


### PR DESCRIPTION
Updates default_visual_language and backfills existing bldgs whose stored visual_language has a "metric" key (containers seeded with the default map). Also adds the standard Phoenix release overlay scripts (bin/migrate, bin/server, plus .bat counterparts) so clean checkouts build a release image with /app/bin/migrate — required by the release_command in fly.dev.toml / fly.prod.toml. Previously these were untracked on a local machine, which broke deploys from fresh clones (e.g. Conductor feature-branch workspaces).