### PR TITLE
Safe container relocation cascade (re-home nested children)

### DIFF
--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -407,6 +407,7 @@ defmodule BldgServer.Buildings do
     else
       old_address = bldg.address
       old_flr = bldg.flr
+      old_bldg_url = bldg.bldg_url
 
       result =
         bldg
@@ -418,6 +419,9 @@ defmodule BldgServer.Buildings do
 
       case result do
         {:ok, %Bldg{address: new_address} = updated} when new_address != old_address ->
+          # Re-home every nested descendant onto the moved subtree, then fix up
+          # roads connected to the container itself.
+          relocate_bldg_cascade(old_address, old_bldg_url, updated)
           BldgServer.Relations.cascade_bldg_relocation(old_address, old_flr, updated)
         _ ->
           :ok
@@ -513,6 +517,63 @@ defmodule BldgServer.Buildings do
 
     # Delete the target bldg itself
     delete_bldg(bldg)
+  end
+
+  @doc """
+  Re-homes every nested descendant of a relocated container.
+
+  When a container bldg moves (`old_address`/`old_bldg_url` -> the moved bldg's
+  new address/bldg_url), each descendant's `address`/`flr` is rebased on the new
+  *address* root and its `bldg_url`/`flr_url` on the new *bldg_url* root (the two
+  hierarchies differ when the container is name-aliased). Roads on descendant
+  floors have their `flr`/`from_address`/`to_address` rebased too — their endpoint
+  coords are floor-local and so are preserved. Everything is updated directly (no
+  re-cascade) and re-broadcast on its new floor.
+  """
+  def relocate_bldg_cascade(old_address, old_bldg_url, %Bldg{} = moved) do
+    old_addr_root = BldgServer.Address.parse!(old_address)
+    new_addr_root = BldgServer.Address.parse!(moved.address)
+    old_url_root = BldgServer.Address.parse!(old_bldg_url)
+    new_url_root = BldgServer.Address.parse!(moved.bldg_url)
+
+    old_address
+    |> list_all_bldgs_in_flr()
+    |> Enum.each(fn d ->
+      attrs = %{
+        "address" => rebase_segment(d.address, old_addr_root, new_addr_root),
+        "flr" => rebase_segment(d.flr, old_addr_root, new_addr_root),
+        "bldg_url" => rebase_segment(d.bldg_url, old_url_root, new_url_root),
+        "flr_url" => rebase_segment(d.flr_url, old_url_root, new_url_root)
+      }
+
+      d
+      |> Bldg.changeset(attrs)
+      |> Repo.update()
+      |> broadcast_bldg_change("bldg_updated")
+    end)
+
+    # Roads on descendant floors: rebase the floor + endpoint addresses (all
+    # address-based); from_x/from_y/to_x/to_y are floor-local and unchanged.
+    old_address
+    |> BldgServer.Relations.list_all_roads_in_flr()
+    |> Enum.each(fn road ->
+      attrs = %{
+        "flr" => rebase_segment(road.flr, old_addr_root, new_addr_root),
+        "from_address" => rebase_segment(road.from_address, old_addr_root, new_addr_root),
+        "to_address" => rebase_segment(road.to_address, old_addr_root, new_addr_root)
+      }
+
+      BldgServer.Relations.update_road(road, attrs)
+    end)
+  end
+
+  # Rebase a single address/url string under a moved root, leaving it untouched
+  # if it doesn't actually sit under that root.
+  defp rebase_segment(str, from_root, to_root) do
+    case BldgServer.Address.rebase(BldgServer.Address.parse!(str), from_root, to_root) do
+      :error -> str
+      rebased -> BldgServer.Address.to_string(rebased)
+    end
   end
 
   defp broadcast_bldg_change({:ok, %Bldg{} = bldg}, event) do

--- a/bldg_server/test/bldg_server/buildings_relocation_test.exs
+++ b/bldg_server/test/bldg_server/buildings_relocation_test.exs
@@ -1,0 +1,120 @@
+defmodule BldgServer.BuildingsRelocationTest do
+  @moduledoc """
+  Container relocation: moving a container bldg re-homes its entire nested
+  subtree (built on Address.rebase/3). Covers the coord case, the name-aliased
+  case where the address and bldg_url hierarchies move independently, and
+  delimiter-safe isolation of sibling subtrees.
+  """
+  use BldgServer.DataCase
+
+  alias BldgServer.Buildings
+  alias BldgServer.Buildings.Bldg
+  alias BldgServer.Relations.Road
+  alias BldgServer.Repo
+
+  setup do
+    seed_ground_floor()
+    :ok
+  end
+
+  test "relocating a container rewrites every descendant's address and flr" do
+    container = bldg(%{address: "g/b(5,5)", bldg_url: "g/b(5,5)", flr: "g", name: "team"})
+
+    child =
+      bldg(%{
+        address: "g/b(5,5)/l0/b(1,1)",
+        bldg_url: "g/b(5,5)/l0/b(1,1)",
+        flr: "g/b(5,5)/l0",
+        flr_url: "g/b(5,5)/l0",
+        name: "child"
+      })
+
+    grandchild =
+      bldg(%{
+        address: "g/b(5,5)/l0/b(1,1)/l0/b(2,2)",
+        bldg_url: "g/b(5,5)/l0/b(1,1)/l0/b(2,2)",
+        flr: "g/b(5,5)/l0/b(1,1)/l0",
+        flr_url: "g/b(5,5)/l0/b(1,1)/l0",
+        name: "grandchild"
+      })
+
+    assert {:ok, _} = Buildings.update_bldg(container, %{"address" => "g/b(9,9)", "bldg_url" => "g/b(9,9)"})
+
+    child = Repo.get(Bldg, child.id)
+    assert child.address == "g/b(9,9)/l0/b(1,1)"
+    assert child.flr == "g/b(9,9)/l0"
+    assert child.bldg_url == "g/b(9,9)/l0/b(1,1)"
+
+    grandchild = Repo.get(Bldg, grandchild.id)
+    assert grandchild.address == "g/b(9,9)/l0/b(1,1)/l0/b(2,2)"
+    assert grandchild.flr == "g/b(9,9)/l0/b(1,1)/l0"
+  end
+
+  test "name-aliased container: address moves but the bldg_url alias stays, each rebased on its own root" do
+    # bldg_url is a name alias ("g/team"); the real address is coordinate-based.
+    container = bldg(%{address: "g/b(5,5)", bldg_url: "g/team", flr: "g", name: "team"})
+
+    child =
+      bldg(%{
+        address: "g/b(5,5)/l0/b(1,1)",
+        bldg_url: "g/team/l0/b(1,1)",
+        flr: "g/b(5,5)/l0",
+        flr_url: "g/team/l0",
+        name: "child"
+      })
+
+    # Only the address (coords) moves; the alias stays "g/team".
+    assert {:ok, _} = Buildings.update_bldg(container, %{"address" => "g/b(9,9)"})
+
+    child = Repo.get(Bldg, child.id)
+    assert child.address == "g/b(9,9)/l0/b(1,1)"
+    assert child.flr == "g/b(9,9)/l0"
+    # the bldg_url hierarchy did not move, so it is left intact
+    assert child.bldg_url == "g/team/l0/b(1,1)"
+    assert child.flr_url == "g/team/l0"
+  end
+
+  test "roads on descendant floors are rebased, with floor-local coords preserved" do
+    container = bldg(%{address: "g/b(5,5)", bldg_url: "g/b(5,5)", flr: "g", name: "team"})
+    bldg(%{address: "g/b(5,5)/l0/b(1,1)", bldg_url: "g/b(5,5)/l0/b(1,1)", flr: "g/b(5,5)/l0", name: "a"})
+    bldg(%{address: "g/b(5,5)/l0/b(2,2)", bldg_url: "g/b(5,5)/l0/b(2,2)", flr: "g/b(5,5)/l0", name: "b"})
+
+    road =
+      road(%{
+        flr: "g/b(5,5)/l0",
+        from_address: "g/b(5,5)/l0/b(1,1)",
+        from_x: 1,
+        from_y: 1,
+        to_address: "g/b(5,5)/l0/b(2,2)",
+        to_x: 2,
+        to_y: 2
+      })
+
+    assert {:ok, _} = Buildings.update_bldg(container, %{"address" => "g/b(9,9)", "bldg_url" => "g/b(9,9)"})
+
+    road = Repo.get(Road, road.id)
+    assert road.flr == "g/b(9,9)/l0"
+    assert road.from_address == "g/b(9,9)/l0/b(1,1)"
+    assert road.to_address == "g/b(9,9)/l0/b(2,2)"
+    # endpoint coords are floor-local — unchanged by the move
+    assert {road.from_x, road.from_y, road.to_x, road.to_y} == {1, 1, 2, 2}
+  end
+
+  test "a sibling subtree is not touched by the relocation" do
+    moving = bldg(%{address: "g/b(5,5)", bldg_url: "g/b(5,5)", flr: "g", name: "moving"})
+    bldg(%{address: "g/b(5,5)/l0/b(1,1)", bldg_url: "g/b(5,5)/l0/b(1,1)", flr: "g/b(5,5)/l0", name: "inner"})
+
+    sibling_child =
+      bldg(%{
+        address: "g/b(7,7)/l0/b(1,1)",
+        bldg_url: "g/b(7,7)/l0/b(1,1)",
+        flr: "g/b(7,7)/l0",
+        name: "sibling-child"
+      })
+
+    assert {:ok, _} = Buildings.update_bldg(moving, %{"address" => "g/b(9,9)", "bldg_url" => "g/b(9,9)"})
+
+    # The sibling's nested child is on a different subtree and must be untouched.
+    assert Repo.get(Bldg, sibling_child.id).address == "g/b(7,7)/l0/b(1,1)"
+  end
+end

--- a/bldg_server/test/bldg_server/protocol_gaps_test.exs
+++ b/bldg_server/test/bldg_server/protocol_gaps_test.exs
@@ -1,15 +1,15 @@
 defmodule BldgServer.ProtocolGapsTest do
   @moduledoc """
-  Executable documentation of two gaps the upcoming protocol work will close:
-
-    1. Relocating a *container* bldg does not rewrite its nested children — their
-       address/flr/bldg_url go stale (only connected roads are cascaded today).
-    2. Bldgs have no footprint (only a point {x,y}), so overlap cannot be
-       expressed and placement only avoids exact-coordinate collisions.
+  Executable documentation of a remaining gap the upcoming protocol work will
+  close: bldgs have no footprint (only a point {x,y}), so overlap cannot be
+  expressed and placement only avoids exact-coordinate collisions.
 
   Each gap has a GREEN characterization test (pins today's behavior — it will
   start failing the moment the feature lands, which is the signal to update it)
   and a `@tag :skip` SPEC test describing the target behavior (unskip when built).
+
+  (The container-relocation gap that used to live here is now closed — see
+  BuildingsRelocationTest.)
   """
   use BldgServer.DataCase
 
@@ -17,66 +17,7 @@ defmodule BldgServer.ProtocolGapsTest do
   alias BldgServer.Buildings.Bldg
   alias BldgServer.Repo
 
-  # ── Gap 1: container relocation leaves children stale ──────────────────────
-
-  describe "container relocation (gap)" do
-    setup do
-      seed_ground_floor()
-      container = bldg(%{address: "g/b(5,5)", bldg_url: "g/b(5,5)", flr: "g", name: "team"})
-
-      child =
-        bldg(%{
-          address: "g/b(5,5)/l0/b(1,1)",
-          bldg_url: "g/b(5,5)/l0/b(1,1)",
-          flr: "g/b(5,5)/l0",
-          name: "child"
-        })
-
-      grandchild =
-        bldg(%{
-          address: "g/b(5,5)/l0/b(1,1)/l0/b(2,2)",
-          bldg_url: "g/b(5,5)/l0/b(1,1)/l0/b(2,2)",
-          flr: "g/b(5,5)/l0/b(1,1)/l0",
-          name: "grandchild"
-        })
-
-      %{container: container, child: child, grandchild: grandchild}
-    end
-
-    test "TODAY: relocating the container leaves descendant addresses stale", ctx do
-      assert {:ok, _moved} =
-               Buildings.update_bldg(ctx.container, %{
-                 "address" => "g/b(9,9)",
-                 "bldg_url" => "g/b(9,9)"
-               })
-
-      # The container moved, but its descendants still point at the old subtree —
-      # they are now orphaned. This is the gap the relocation feature must fix.
-      assert Repo.get(Bldg, ctx.child.id).address == "g/b(5,5)/l0/b(1,1)"
-      assert Repo.get(Bldg, ctx.child.id).flr == "g/b(5,5)/l0"
-      assert Repo.get(Bldg, ctx.grandchild.id).address == "g/b(5,5)/l0/b(1,1)/l0/b(2,2)"
-    end
-
-    @tag skip: "pending: container relocation cascade — unskip when implemented"
-    test "TARGET: relocating the container rewrites every descendant's address/flr/bldg_url", ctx do
-      assert {:ok, _moved} =
-               Buildings.update_bldg(ctx.container, %{
-                 "address" => "g/b(9,9)",
-                 "bldg_url" => "g/b(9,9)"
-               })
-
-      child = Repo.get(Bldg, ctx.child.id)
-      assert child.address == "g/b(9,9)/l0/b(1,1)"
-      assert child.flr == "g/b(9,9)/l0"
-      assert child.bldg_url == "g/b(9,9)/l0/b(1,1)"
-
-      grandchild = Repo.get(Bldg, ctx.grandchild.id)
-      assert grandchild.address == "g/b(9,9)/l0/b(1,1)/l0/b(2,2)"
-      assert grandchild.flr == "g/b(9,9)/l0/b(1,1)/l0"
-    end
-  end
-
-  # ── Gap 2: bldgs are dimensionless points; overlap is unrepresentable ───────
+  # ── Gap: bldgs are dimensionless points; overlap is unrepresentable ─────────
 
   describe "bldg footprint / overlap (gap)" do
     test "TODAY: the schema models a single point, with no width/height footprint" do


### PR DESCRIPTION
## Why

The first of the two functional protocol features you described: **relocating a container bldg with a safe update of all its nested children**. Built on `Address.rebase/3` from #22 (this PR is **based on `refactor/address-module`** — merge #21 → #22 → this).

## What

When `update_bldg/2` sees a container's address change, `relocate_bldg_cascade/3` re-homes the whole subtree:
- **descendant bldgs** — rebases each one's `address`/`flr` on the new **address** root and its `bldg_url`/`flr_url` on the new **bldg_url** root; the two hierarchies move independently when the container is name-aliased (e.g. `bldg_url` `g/team` vs `address` `g/b(5,5)`)
- **roads on descendant floors** — rebases `flr` + endpoint addresses; their `from/to` coords are floor-local, so they're preserved
- descendant lookup is delimiter-safe (sibling subtrees untouched); updates are applied directly (no re-cascade) and re-broadcast on the new floor

Previously only roads connected to the container itself were cascaded, so descendant bldgs were orphaned and descendant roads left dangling.

## Tests

`BuildingsRelocationTest` covers four cases — the coord container, the name-aliased container (address moves, alias stays, each rebased on its own root), descendant-road rebasing with coords preserved, and sibling-subtree isolation. Full suite: 184 tests, 0 failures, 2 skipped (the remaining dimension specs). The relocation gap is removed from `protocol_gaps_test`, which now documents only the footprint/overlap gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D84sHx7DejidSB1RojjWZ
