### PR TITLE
Parse width/height in the /create chat command

### DIFF
--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -186,6 +186,8 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         color,
         size,
         variant,
+        width,
+        height,
         msg
       ) do
     # create a bldg with the given entity-type & name, inside the given flr & bldg
@@ -234,6 +236,8 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         |> put_if_present("color", color)
         |> put_if_present("size", size)
         |> put_if_present("variant", variant)
+        |> put_if_present("width", width)
+        |> put_if_present("height", height)
 
       Buildings.build(entity)
       |> Buildings.create_bldg(msg)
@@ -259,11 +263,16 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     color = ""
     size = ""
     variant = ""
+    # nil (not "") sentinel: dimensions are integers, so put_if_present skips
+    # them when unspecified and the schema default (1) applies.
+    width = nil
+    height = nil
 
     # Loop through parameters with index
     Enum.with_index(parameters_tokens)
     |> Enum.reduce(
-      {name, web_url, summary, category, picture_url, data_url, state, color, size, variant},
+      {name, web_url, summary, category, picture_url, data_url, state, color, size, variant, width,
+       height},
       fn
         {"name", i}, acc ->
           name = Enum.at(parameters_tokens, i + 1)
@@ -291,7 +300,9 @@ defmodule BldgServerWeb.BldgCommandExecutor do
                   "state",
                   "color",
                   "size",
-                  "variant"
+                  "variant",
+                  "width",
+                  "height"
                 ],
                 x
               )
@@ -336,12 +347,18 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           acc = put_elem(acc, 9, variant)
           acc
 
+        {"width", i}, acc ->
+          put_elem(acc, 10, parse_dimension(Enum.at(parameters_tokens, i + 1)))
+
+        {"height", i}, acc ->
+          put_elem(acc, 11, parse_dimension(Enum.at(parameters_tokens, i + 1)))
+
         _, acc ->
           acc
       end
     )
     |> then(fn {name, web_url, summary, category, picture_url, data_url, state, color, size,
-                variant} ->
+                variant, width, height} ->
       create_bldg_from_command(
         entity_type,
         name,
@@ -354,9 +371,22 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         color,
         size,
         variant,
+        width,
+        height,
         msg
       )
     end)
+  end
+
+  # Dimensions must be whole positive cell-counts; a missing or non-integer token
+  # yields nil so the schema default (1) applies rather than a bad value.
+  defp parse_dimension(nil), do: nil
+
+  defp parse_dimension(token) do
+    case Integer.parse(token) do
+      {n, ""} when n > 0 -> n
+      _ -> nil
+    end
   end
 
   # move bldg

--- a/bldg_server/test/bldg_server_web/bldg_command_executor_more_test.exs
+++ b/bldg_server/test/bldg_server_web/bldg_command_executor_more_test.exs
@@ -149,6 +149,39 @@ defmodule BldgServerWeb.BldgCommandExecutorMoreTest do
       assert child.state == "Todo"
     end
 
+    test "parses width and height into the bldg footprint", %{msg: msg} do
+      {:ok, child} =
+        BldgCommandExecutor.execute_command(
+          ["/create", "task", "bldg", "with", "name", "t", "width", "3", "height", "2"],
+          msg
+        )
+
+      assert child.width == 3
+      assert child.height == 2
+    end
+
+    test "defaults to a 1x1 footprint when dimensions are omitted, and a non-integer is ignored", %{msg: msg} do
+      {:ok, child} =
+        BldgCommandExecutor.execute_command(
+          ["/create", "task", "bldg", "with", "name", "t", "width", "wide"],
+          msg
+        )
+
+      assert child.width == 1
+      assert child.height == 1
+    end
+
+    test "summary stops at the width keyword rather than swallowing it", %{msg: msg} do
+      {:ok, child} =
+        BldgCommandExecutor.execute_command(
+          ["/create", "task", "bldg", "with", "name", "t", "summary", "a", "tall", "one", "height", "4"],
+          msg
+        )
+
+      assert child.summary == "a tall one"
+      assert child.height == 4
+    end
+
     test "rejects a non-owner", %{msg: msg} do
       assert_raise RuntimeError, ~r/not authorized/, fn ->
         BldgCommandExecutor.execute_command(


### PR DESCRIPTION
## Why

Follow-up to the footprint feature (#24): bldgs gained `width`/`height` on the schema, but the `/create` chat command had no way to set them, so chat-created bldgs were always 1×1. This wires the dimensions into the command.

## What

`/create <type> bldg with ... width <n> height <n>` now sets the footprint. Implementation mirrors the existing color/size/variant handling:
- `width`/`height` keywords added to the `/create` parser; each takes the next token, parsed as a **positive integer** (a missing or non-integer value → `nil`, so the schema default `1` applies — no bad values persisted)
- added to the `summary` stop-list so a preceding `summary ...` doesn't swallow `width`/`height`
- flow through `create_bldg_from_command` via the existing `put_if_present`

Example: `/create task bldg with name onboarding width 3 height 2`

## Tests

Three cases in the `/create` suite: dimensions parse into the footprint; omitted/non-integer falls back to 1×1; and `summary` stops at the `width`/`height` keyword instead of consuming it. Full suite: 194 tests, 0 failures.

## Note

`/create` sets an explicit address (derived from `say_location`), so this **persists** the footprint but does not engage the overlap-aware placement from #24 (that only runs for auto-placement). Rejecting overlap on explicit placement remains the separate follow-up flagged in #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D84sHx7DejidSB1RojjWZ
