### PR TITLE
Reject creating a bldg whose footprint overlaps an existing one

### DIFF
--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -353,6 +353,7 @@ defmodule BldgServer.Buildings do
     cs =
       %Bldg{}
       |> Bldg.changeset(attrs)
+      |> reject_if_overlapping()
 
     # TODO figure out better way to notify bldg_url & address
     created_bldg_url = attrs["bldg_url"]
@@ -374,6 +375,33 @@ defmodule BldgServer.Buildings do
         # pattern-match {:error, _} — can render a 422 rather than 500.
         Logger.error("Failed to prepare bldg for writing to database: #{inspect(cs.errors)}")
         {:error, cs}
+    end
+  end
+
+  # Reject a create whose footprint would overlap an existing bldg on the same
+  # floor. Auto-placement already avoids this (find_free_footprint chooses a
+  # clear slot); this guards the *explicit*-placement path — where a caller
+  # supplies exact coords — since the unique-address constraint only catches an
+  # identical origin, not a partial footprint overlap.
+  defp reject_if_overlapping(%Ecto.Changeset{valid?: false} = cs), do: cs
+
+  defp reject_if_overlapping(cs) do
+    flr = Ecto.Changeset.get_field(cs, :flr)
+    x = Ecto.Changeset.get_field(cs, :x)
+    y = Ecto.Changeset.get_field(cs, :y)
+    width = Ecto.Changeset.get_field(cs, :width) || 1
+    height = Ecto.Changeset.get_field(cs, :height) || 1
+
+    if is_binary(flr) and is_integer(x) and is_integer(y) do
+      candidate = %{x: x, y: y, width: width, height: height}
+
+      if Enum.any?(occupied_footprints(flr), &footprints_overlap?(candidate, &1)) do
+        Ecto.Changeset.add_error(cs, :address, "footprint overlaps an existing bldg on this floor")
+      else
+        cs
+      end
+    else
+      cs
     end
   end
 

--- a/bldg_server/test/bldg_server/buildings_dimensions_test.exs
+++ b/bldg_server/test/bldg_server/buildings_dimensions_test.exs
@@ -9,6 +9,19 @@ defmodule BldgServer.BuildingsDimensionsTest do
   alias BldgServer.Buildings.Bldg
   alias BldgServer.Repo
 
+  defp create_attrs(overrides) do
+    Map.merge(
+      %{
+        "flr" => "g",
+        "is_composite" => false,
+        "entity_type" => "building",
+        "flr_level" => 0,
+        "nesting_depth" => 0
+      },
+      overrides
+    )
+  end
+
   describe "persistence" do
     test "a bldg persists its width/height footprint" do
       b = bldg(%{address: "g/b(1,1)", bldg_url: "g/b(1,1)", width: 3, height: 2})
@@ -92,6 +105,49 @@ defmodule BldgServer.BuildingsDimensionsTest do
 
       new_footprint = %{x: placed["x"], y: placed["y"], width: 3, height: 3}
       refute Buildings.footprints_overlap?(new_footprint, existing)
+    end
+  end
+
+  describe "create_bldg overlap rejection (explicit placement)" do
+    setup do
+      seed_ground_floor()
+      # A 3x3 bldg covering x:1..3, y:1..3 on the ground floor.
+      bldg(%{flr: "g", address: "g/b(1,1)", bldg_url: "g/b(1,1)", x: 1, y: 1, width: 3, height: 3, name: "big"})
+      :ok
+    end
+
+    test "rejects a create whose footprint overlaps an existing bldg on the floor" do
+      # 2x2 at {2,2} covers x:2..3, y:2..3 — intersects the existing 3x3. The
+      # address is unique, so only the footprint check can catch this.
+      attrs =
+        create_attrs(%{
+          "address" => "g/b(2,2)",
+          "bldg_url" => "g/b(2,2)",
+          "name" => "overlapper",
+          "x" => 2,
+          "y" => 2,
+          "width" => 2,
+          "height" => 2
+        })
+
+      assert {:error, cs} = Buildings.create_bldg(attrs)
+      assert Enum.any?(errors_on(cs).address, &(&1 =~ "overlaps"))
+    end
+
+    test "allows an edge-adjacent footprint (no overlap)" do
+      # 2x2 at {4,1} covers x:4..5 — flush against the existing bldg's right edge.
+      attrs =
+        create_attrs(%{
+          "address" => "g/b(4,1)",
+          "bldg_url" => "g/b(4,1)",
+          "name" => "neighbor",
+          "x" => 4,
+          "y" => 1,
+          "width" => 2,
+          "height" => 2
+        })
+
+      assert {:ok, _bldg} = Buildings.create_bldg(attrs)
     end
   end
 end


### PR DESCRIPTION
## Why

Closes the last open footprint follow-up from #24: bldgs gained dimensions and auto-placement avoids overlap, but **explicit** placement (a caller/command supplying exact coords) could still overlap — the unique-address constraint only catches an identical origin, not a partial footprint overlap.

## What

`create_bldg/2` now runs the candidate footprint against every footprint already on the floor (`occupied_footprints` + `footprints_overlap?`) and returns `{:error, changeset}` on a conflict. So:
- `BldgController.create` renders **422** (via the existing fallback) instead of persisting an overlapping bldg
- auto-placement is unaffected (it already chooses a clear slot, so the check passes)

The guard is skipped when position fields aren't all present, and it only engages for valid changesets.

## Tests

`create_bldg` rejects an overlapping footprint (distinct address, so only the footprint check can catch it) and allows an edge-adjacent one. Full suite: 193 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D84sHx7DejidSB1RojjWZ
