### PR TITLE
bldg-server goal-plan fixes: cabinet shelf heights + /connect resilience

### DIFF
--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -20,7 +20,7 @@ defmodule BldgServer.Buildings do
     "storage" => %{"3d_object" => "storageBuilding", "flr_height" => "0.7", "flr0_height" => "0.03"},
     "costs" => %{"3d_object" => "chestOfDrawers", "flr_height" => "2.57", "flr0_height" => "0.067"},
     "inbox" => %{"3d_object" => "tray", "flr_height" => "2.57", "flr0_height" => "0.067"},
-    "sales" => %{"3d_object" => "bookCabinet", "flr_height" => "0.5", "flr0_height" => "0.13"},
+    "sales" => %{"3d_object" => "bookCabinet", "flr_height" => "0.5", "flr0_height" => "-0.12"},
     "goal" => %{"3d_object" => "livingRoomTable", "flr_height" => "1.08", "flr0_height" => "1.11"},
     "purpose" => %{"3d_object" => "whiteboard"},
     "cantata" => %{"3d_object" => "presentationStand"},

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -20,7 +20,7 @@ defmodule BldgServer.Buildings do
     "storage" => %{"3d_object" => "storageBuilding", "flr_height" => "0.7", "flr0_height" => "0.03"},
     "costs" => %{"3d_object" => "chestOfDrawers", "flr_height" => "2.57", "flr0_height" => "0.067"},
     "inbox" => %{"3d_object" => "tray", "flr_height" => "2.57", "flr0_height" => "0.067"},
-    "sales" => %{"3d_object" => "bookCabinet", "flr_height" => "3.0", "flr0_height" => "1.3"},
+    "sales" => %{"3d_object" => "bookCabinet", "flr_height" => "0.5", "flr0_height" => "0.13"},
     "goal" => %{"3d_object" => "livingRoomTable", "flr_height" => "1.08", "flr0_height" => "1.11"},
     "purpose" => %{"3d_object" => "whiteboard"},
     "cantata" => %{"3d_object" => "presentationStand"},

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -86,34 +86,46 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     else
       # TODO return proper errors
       flr_url = msg["say_flr_url"]
-      bldg1_url = "#{flr_url}#{Buildings.address_delimiter()}#{name1}"
-      bldg1 = Buildings.get_by_bldg_url(bldg1_url)
-      from_addr = bldg1.address
-      {from_x, from_y} = Buildings.extract_coords(from_addr)
-      bldg2_url = "#{flr_url}#{Buildings.address_delimiter()}#{name2}"
-      bldg2 = Buildings.get_by_bldg_url(bldg2_url)
-      to_addr = bldg2.address
-      {to_x, to_y} = Buildings.extract_coords(to_addr)
+      bldg1 = Buildings.get_by_bldg_url("#{flr_url}#{Buildings.address_delimiter()}#{name1}")
+      bldg2 = Buildings.get_by_bldg_url("#{flr_url}#{Buildings.address_delimiter()}#{name2}")
 
-      road = %{
-        "flr" => msg["say_flr"],
-        "flr_url" => msg["say_flr_url"],
-        "from_address" => from_addr,
-        "to_address" => to_addr,
-        "from_x" => from_x,
-        "from_y" => from_y,
-        "to_x" => to_x,
-        "to_y" => to_y,
-        "owners" => [msg["resident_email"]],
-        "color" => color,
-        "road_class" => road_class || "road"
-      }
+      cond do
+        is_nil(bldg1) or is_nil(bldg2) ->
+          # A road endpoint isn't on this floor: a race-late create (the bldg's
+          # relocate echo hasn't landed) or a stale re-emit (the bldg moved or was
+          # removed by a later render). Skip gracefully instead of crashing on
+          # nil.address — that raised an Internal Server Error (HTTP 500) for what
+          # is a benign, self-correcting condition: batteries re-emit roads
+          # idempotently, so a transient miss heals on a later pass.
+          IO.puts("~~ /connect skipped: endpoint not found on #{flr_url} (#{name1} and/or #{name2})")
+          {:ok, :skipped}
 
-      # Idempotent: re-emitting an identical road (watch / re-render passes, or
-      # the organize-check's road re-emission) must not stack duplicate records.
-      case Relations.find_road(msg["say_flr"], from_addr, to_addr) do
-        nil -> Relations.create_road(road)
-        existing -> {:ok, existing}
+        true ->
+          from_addr = bldg1.address
+          {from_x, from_y} = Buildings.extract_coords(from_addr)
+          to_addr = bldg2.address
+          {to_x, to_y} = Buildings.extract_coords(to_addr)
+
+          road = %{
+            "flr" => msg["say_flr"],
+            "flr_url" => msg["say_flr_url"],
+            "from_address" => from_addr,
+            "to_address" => to_addr,
+            "from_x" => from_x,
+            "from_y" => from_y,
+            "to_x" => to_x,
+            "to_y" => to_y,
+            "owners" => [msg["resident_email"]],
+            "color" => color,
+            "road_class" => road_class || "road"
+          }
+
+          # Idempotent: re-emitting an identical road (watch / re-render passes, or
+          # the organize-check's road re-emission) must not stack duplicate records.
+          case Relations.find_road(msg["say_flr"], from_addr, to_addr) do
+            nil -> Relations.create_road(road)
+            existing -> {:ok, existing}
+          end
       end
     end
   end


### PR DESCRIPTION
Consolidated bldg-server changes for the goal-plan visualization so a single deploy carries all of them (avoids the cabinet tuning being lost when deploying from master).

1. **bookCabinet (`sales`) shelf heights** — `flr_height 3.0 → 0.5` for the rescaled Unity `Shelves4` prefab, so the 5 artifact shelves are spaced to match the mesh.
2. **`flr0_height 1.3 → -0.12`** — the artifacts sat at the shelf-floor Y but floated ~half a gap above the planks (the door-knob reference I first used is mid-compartment). Lowered so shelf-0 rests on its plank; spacing unchanged.
3. **`/connect` skips a missing endpoint** — reading `bldg.address` on a `nil` lookup (race-late create, or stale re-emit after a bldg moved/was removed) crashed with HTTP 500. Now returns `{:ok, :skipped}`; resolvable roads on the same pass still draw. (Supersedes PR #29.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)