### PR TITLE
Raise bldg name/url length limit + fail loud on create failure

### DIFF
--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -365,6 +365,21 @@ defmodule BldgServer.Buildings do
     case cs.errors do
       [] ->
         result = Repo.insert(cs)
+
+        # FAIL LOUD: command execution is async, so the HTTP caller already got
+        # its 200 — a failed INSERT must be logged clearly here or it vanishes
+        # silently (the "artifact created but never rendered" class of bug).
+        case result do
+          {:error, failed_cs} ->
+            Logger.error(
+              "Failed to create bldg #{inspect(created_bldg_url)}: " <>
+                "#{inspect(failed_cs.errors)}"
+            )
+
+          _ ->
+            :ok
+        end
+
         notify_bldg_created(result, "bldg_created", created_bldg_ids, triggering_chat_msg)
         broadcast_bldg_change(result, "bldg_created")
         result

--- a/bldg_server/lib/bldg_server/buildings/bldg.ex
+++ b/bldg_server/lib/bldg_server/buildings/bldg.ex
@@ -4,6 +4,13 @@ defmodule BldgServer.Buildings.Bldg do
 
   @sizes ~w(XS S M L XL XXL)
 
+  # address/bldg_url/web_url are `:text` (no varchar cap) but are UNIQUE-INDEXED,
+  # and a Postgres btree index entry can't exceed ~2704 bytes. Guard well under
+  # that so an over-long value fails with a CLEAR changeset error (routed through
+  # create_bldg's error logging) instead of crashing the insert — which used to
+  # no-op silently. See the widen_bldg_text_columns migration.
+  @max_indexed_len 2000
+
   schema "bldgs" do
     field(:address, :string)
     field(:category, :string)
@@ -79,6 +86,9 @@ defmodule BldgServer.Buildings.Bldg do
       :flr_level,
       :nesting_depth
     ])
+    |> validate_length(:bldg_url, max: @max_indexed_len)
+    |> validate_length(:address, max: @max_indexed_len)
+    |> validate_length(:web_url, max: @max_indexed_len)
     |> validate_inclusion(:size, @sizes)
     |> validate_number(:width, greater_than: 0)
     |> validate_number(:height, greater_than: 0)

--- a/bldg_server/priv/repo/migrations/20260712000000_widen_bldg_text_columns.exs
+++ b/bldg_server/priv/repo/migrations/20260712000000_widen_bldg_text_columns.exs
@@ -1,0 +1,41 @@
+defmodule BldgServer.Repo.Migrations.WidenBldgTextColumns do
+  use Ecto.Migration
+
+  # Ecto's `:string` maps to Postgres `varchar(255)`. A bldg's `bldg_url`,
+  # `flr_url` and `address` embed the full nested path (repeated per level), so
+  # deeply-nested content (e.g. an artifacts-cabinet leaf:
+  # goal/milestone/enabler/task/artifacts/Documents/001) blows past 255 chars —
+  # and because command execution is async, the INSERT then failed SILENTLY (the
+  # caller already got its 200 while no bldg was created). Widen the columns that
+  # can hold long nested paths, URLs or free text to `:text` (no length limit) so
+  # those creates succeed. See also the changeset length guard + louder create_bldg.
+  def up do
+    alter table(:bldgs) do
+      modify :bldg_url, :text
+      modify :flr_url, :text
+      modify :address, :text
+      modify :name, :text
+      modify :flr, :text
+      modify :summary, :text
+      modify :web_url, :text
+      modify :picture_url, :text
+      modify :category, :text
+      modify :entity_type, :text
+    end
+  end
+
+  def down do
+    alter table(:bldgs) do
+      modify :bldg_url, :string
+      modify :flr_url, :string
+      modify :address, :string
+      modify :name, :string
+      modify :flr, :string
+      modify :summary, :string
+      modify :web_url, :string
+      modify :picture_url, :string
+      modify :category, :string
+      modify :entity_type, :string
+    end
+  end
+end


### PR DESCRIPTION
A deep bldg's bldg_url/flr_url/address embed the full nested path, so deeply nested content (an artifacts-cabinet leaf) blew past the varchar(255) default of Ecto :string columns — and because command execution is async, the caller got a 200 while the INSERT failed SILENTLY (an artifact "created" but never rendered; cost a full debug cycle in the file-system-battery).

- Migration widen_bldg_text_columns: bldg_url/flr_url/address/name/flr/summary/ web_url/picture_url/category/entity_type -> :text (no 255 cap).
- Bldg.changeset: validate_length(max: 2000) on the UNIQUE-indexed text columns (address/bldg_url/web_url) — a btree index entry can't exceed ~2704 bytes, so guard under it; an over-long value now yields a CLEAR changeset error (routed through create_bldg's existing error logging) instead of crashing the insert.
- create_bldg: also Logger.error when Repo.insert itself returns {:error}, so a failed insert leaves a loud trail (the changeset-error path already did).


Claude-Session: https://claude.ai/code/session_01SYuba1NmuAhh3bh2W144Nu